### PR TITLE
Update for modern Anki versions

### DIFF
--- a/BuildZip.bat
+++ b/BuildZip.bat
@@ -1,5 +1,7 @@
 @ECHO OFF
 REM A Windows 'build' script.
+REM
+REM If you modify this, make corresponding changes to BuildZip.sh
 
 IF NOT EXIST "C:\Program Files/7-Zip/7z.exe" (
   ECHO This script uses 7-Zip to build the .zip file, but 7-Zip does not seem to be installed, so the script will fail.

--- a/BuildZip.bat
+++ b/BuildZip.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+REM A Windows 'build' script.
+
+IF NOT EXIST "C:\Program Files/7-Zip/7z.exe" (
+  ECHO This script uses 7-Zip to build the .zip file, but 7-Zip does not seem to be installed, so the script will fail.
+  ECHO The script also assumes that 7-Zip is installed in its default location, C:\Program Files/7-Zip/7z.exe
+  ECHO So please do not change the default install location of 7-zip when you install it.
+  EXIT /B 1
+)
+
+REM Delete and recreate temporary folder so we don't end up copying old files
+RMDIR /S /Q %TEMP%\FlashGrabBuild
+MKDIR %TEMP%\FlashGrabBuild
+
+REM Copy files into folder
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xml\*.* %TEMP%\FlashGrabBuild\xml\
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xpath\*.* %TEMP%\FlashGrabBuild\xpath\
+REM No /E for syncxml since we don't want to include docsrc or samples directories
+xcopy /D /Y /exclude:ExcludedFilesWindows.txt syncxml\*.* %TEMP%\FlashGrabBuild\syncxml\
+REM We do want one file from samples, but it should be in a top-level folder in the zip file
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\samples\lift-dictionary.apkg %TEMP%\FlashGrabBuild\samples\
+REM The default config also needs to live in the top-level folder
+move %TEMP%\FlashGrabBuild\syncxml\SyncFromXML_config_default.txt %TEMP%\FlashGrabBuild\
+xcopy /D /Y /exclude:ExcludedFilesWindows.txt __init__.py %TEMP%\FlashGrabBuild\
+xcopy /D /Y /exclude:ExcludedFilesWindows.txt manifest.json %TEMP%\FlashGrabBuild\
+
+PUSHD %TEMP%\FlashGrabBuild
+"C:\Program Files/7-Zip/7z.exe" a FlashGrab.zip syncxml samples xml xpath __init__.py manifest.json SyncFromXML_config_default.txt
+POPD
+
+MOVE %TEMP%\FlashGrabBuild\FlashGrab.zip .
+
+ECHO FlashGrab.zip file created!
+DIR FlashGrab.zip
+PAUSE

--- a/BuildZip.sh
+++ b/BuildZip.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # A Linux build script
 
+# If you modify this, make corresponding changes to BuildZip.bat
+
 which 7z || (
   echo 7zip not found. Please install the 7zip package, e.g. sudo apt install 7zip or sudo pacman -S 7zip
   exit 1

--- a/BuildZip.sh
+++ b/BuildZip.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# A Linux build script
+
+which 7z || (
+  echo 7zip not found. Please install the 7zip package, e.g. sudo apt install 7zip or sudo pacman -S 7zip
+  exit 1
+)
+
+# Delete and recreate temporary folder so we don't end up copying old files
+rm -rf /tmp/FlashGrabBuild
+mkdir /tmp/FlashGrabBuild
+
+# Copy files into folder
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xml /tmp/FlashGrabBuild
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xpath /tmp/FlashGrabBuild
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt syncxml /tmp/FlashGrabBuild
+
+cp -u -v __init__.py /tmp/FlashGrabBuild
+cp -u -v manifest.json /tmp/FlashGrabBuild
+
+# Some files under syncxml need to live in top-level directory
+mv /tmp/FlashGrabBuild/syncxml/SyncFromXML_config_default.txt /tmp/FlashGrabBuild
+mkdir -p /tmp/FlashGrabBuild/samples
+mv /tmp/FlashGrabBuild/syncxml/samples/lift-dictionary.apkg /tmp/FlashGrabBuild/samples
+
+# Rest of samples and docsrc from syncxml dir doesn't need to be in the addon, to save file size
+rm -rf /tmp/FlashGrabBuild/syncxml/docsrc
+rm -rf /tmp/FlashGrabBuild/syncxml/samples
+
+pushd /tmp/FlashGrabBuild
+7z a FlashGrab.zip syncxml samples xml xpath __init__.py manifest.json SyncFromXML_config_default.txt
+popd
+
+mv /tmp/FlashGrabBuild/FlashGrab.zip .
+ls -l FlashGrab.zip

--- a/CopyFilesToAddons.bat
+++ b/CopyFilesToAddons.bat
@@ -20,6 +20,7 @@ REM We do want one file from samples, but it should be in a top-level "samples" 
 xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\samples\lift-dictionary.apkg "%ROOTFOLDER%\samples\"
 xcopy /D /Y __init__.py "%ROOTFOLDER%\"
 xcopy /D /Y manifest.json "%ROOTFOLDER%\"
+REM Default config should also be in plugin root
 xcopy /D /Y syncxml\SyncFromXML_config_default.txt "%ROOTFOLDER%\"
 
 PAUSE

--- a/CopyFilesToAddons.bat
+++ b/CopyFilesToAddons.bat
@@ -11,6 +11,10 @@ xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xml\*.* %USERPROFILE%\documents
 xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xpath\*.* %USERPROFILE%\documents\Anki\addons\xpath\
 xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt distutils\*.* %USERPROFILE%\documents\Anki\addons\distutils\
 xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\*.* %USERPROFILE%\documents\Anki\addons\syncxml\
-xcopy /D /Y syncx.py %USERPROFILE%\documents\Anki\addons\
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\samples\*.* %USERPROFILE%\documents\Anki\addons\samples\
+xcopy /D /Y __init__.py %USERPROFILE%\documents\Anki\addons\
+REM WAS: xcopy /D /Y syncx.py %USERPROFILE%\documents\Anki\addons\
+xcopy /D /Y manifest.json %USERPROFILE%\documents\Anki\addons\
+xcopy /D /Y syncxml\SyncFromXML_config_default.txt %USERPROFILE%\documents\Anki\addons\
 
 PAUSE

--- a/CopyFilesToAddons.bat
+++ b/CopyFilesToAddons.bat
@@ -2,19 +2,24 @@ ECHO OFF
 REM A Windows 'build' script. Run this after editing the addon's files. Then restart Anki. 
 REM Don't make edits over there in addons directly, as VCS won't see them, and an Anki or addon upgrade
 REM might destroy them.
+
+REM IMPORTANT: If you change the plugin package in manifest.json, make the same change to PLUGIN_NAME below
 ECHO ON
+
+SET PLUGIN_NAME=FlashGrab
+SET ROOTFOLDER=%APPDATA%\Anki2\addons21\%PLUGIN_NAME%
 
 REM copy all modified (D) files and folders (even E, empty ones), and overwrite (Y) without prompting
 REM (Like Anki's own deployment, this does NOT remove any files. The simplest way to do so manually here is to delete the addons folder, then re-run.)
 
-xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xml\*.* %USERPROFILE%\documents\Anki\addons\xml\
-xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xpath\*.* %USERPROFILE%\documents\Anki\addons\xpath\
-xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt distutils\*.* %USERPROFILE%\documents\Anki\addons\distutils\
-xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\*.* %USERPROFILE%\documents\Anki\addons\syncxml\
-xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\samples\*.* %USERPROFILE%\documents\Anki\addons\samples\
-xcopy /D /Y __init__.py %USERPROFILE%\documents\Anki\addons\
-REM WAS: xcopy /D /Y syncx.py %USERPROFILE%\documents\Anki\addons\
-xcopy /D /Y manifest.json %USERPROFILE%\documents\Anki\addons\
-xcopy /D /Y syncxml\SyncFromXML_config_default.txt %USERPROFILE%\documents\Anki\addons\
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xml\*.* "%ROOTFOLDER%\xml\"
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt xpath\*.* "%ROOTFOLDER%\xpath\"
+REM No /E for syncxml since we don't want to include docsrc or samples directories
+xcopy /D /Y /exclude:ExcludedFilesWindows.txt syncxml\*.* "%ROOTFOLDER%\syncxml\"
+REM We do want one file from samples, but it should be in a top-level "samples" folder in the addons directory
+xcopy /D /E /Y /exclude:ExcludedFilesWindows.txt syncxml\samples\lift-dictionary.apkg "%ROOTFOLDER%\samples\"
+xcopy /D /Y __init__.py "%ROOTFOLDER%\"
+xcopy /D /Y manifest.json "%ROOTFOLDER%\"
+xcopy /D /Y syncxml\SyncFromXML_config_default.txt "%ROOTFOLDER%\"
 
 PAUSE

--- a/CopyFilesToAddons.sh
+++ b/CopyFilesToAddons.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
 
 # To run this script from the terminal command line: ./CopyFilesToAddons.sh
-# A Linux 'build' script. Run this after editing the addon's files. Then restart Anki. 
+# A Linux 'build' script. Run this after editing the addon's files. Then restart Anki.
 # Don't make edits over there in addons directly, as VCS won't see them, and an Anki or addon upgrade might destroy them.
+
+# IMPORTANT: If you change the plugin package in manifest.json, make the same change to PLUGIN_NAME below
+PLUGIN_NAME=FlashGrab
 
 # Copy recursively (-r) all modified files and folders, except the excluded ones
 # (Like Anki's own deployment, this does NOT remove any files. The simplest way to do so manually here is to delete the addons folder, then re-run.)
 
-mkdir -p ~/Anki/addons
-rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xml ~/Anki/addons/
-rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xpath ~/Anki/addons/
-rsync -r -u -v --exclude-from ExcludedFilesLinux.txt distutils ~/Anki/addons/
-rsync -r -u -v --exclude-from ExcludedFilesLinux.txt syncxml ~/Anki/addons/
-cp -r -u -v syncx.py ~/Anki/addons/
+# Use XDG_DATA_HOME if present, otherwise default to ~/.local/share
+DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+PLUGIN_HOME="${DATA_HOME}/Anki2/addons21/${PLUGIN_NAME}"
+
+mkdir -p "${PLUGIN_HOME}"
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xml "${PLUGIN_HOME}/"
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xpath "${PLUGIN_HOME}/"
+rsync -r -u -v --exclude-from ExcludedFilesLinux.txt syncxml "${PLUGIN_HOME}/"
+# No -r for syncxml since we don't want to include docsrc or samples directories
+# syncxml samples dir should be at the top level of the plugin directory and only contain one file
+mkdir -p "${PLUGIN_HOME}/samples"
+mv "${PLUGIN_HOME}/syncxml/samples/lift-dictionary.apkg" "${PLUGIN_HOME}/samples/"
+# Default config should also be in plugin root
+mv "${PLUGIN_HOME}/syncxml/SyncFromXML_config_default.txt" "${PLUGIN_HOME}/"
+# Rest of samples, as well as docsrc folder, not needed
+rm -rf "${PLUGIN_HOME}/syncxml/samples"
+rm -rf "${PLUGIN_HOME}/syncxml/docsrc"
+cp -u -v __init__.py "${PLUGIN_HOME}/"
+cp -u -v manifest.json "${PLUGIN_HOME}/"

--- a/CopyFilesToAddons.sh
+++ b/CopyFilesToAddons.sh
@@ -17,15 +17,12 @@ PLUGIN_HOME="${DATA_HOME}/Anki2/addons21/${PLUGIN_NAME}"
 mkdir -p "${PLUGIN_HOME}"
 rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xml "${PLUGIN_HOME}/"
 rsync -r -u -v --exclude-from ExcludedFilesLinux.txt xpath "${PLUGIN_HOME}/"
-rsync -r -u -v --exclude-from ExcludedFilesLinux.txt syncxml "${PLUGIN_HOME}/"
 # No -r for syncxml since we don't want to include docsrc or samples directories
-# syncxml samples dir should be at the top level of the plugin directory and only contain one file
+rsync -u -v --exclude-from ExcludedFilesLinux.txt syncxml "${PLUGIN_HOME}/"
+# We do want one file from samples, but it should be in a top-level "samples" folder in the addons directory
 mkdir -p "${PLUGIN_HOME}/samples"
-mv "${PLUGIN_HOME}/syncxml/samples/lift-dictionary.apkg" "${PLUGIN_HOME}/samples/"
-# Default config should also be in plugin root
-mv "${PLUGIN_HOME}/syncxml/SyncFromXML_config_default.txt" "${PLUGIN_HOME}/"
-# Rest of samples, as well as docsrc folder, not needed
-rm -rf "${PLUGIN_HOME}/syncxml/samples"
-rm -rf "${PLUGIN_HOME}/syncxml/docsrc"
+rsync -u -v --exclude-from ExcludedFilesLinux.txt syncxml/samples/lift-dictionary.apkg "${PLUGIN_HOME}/samples/"
 cp -u -v __init__.py "${PLUGIN_HOME}/"
 cp -u -v manifest.json "${PLUGIN_HOME}/"
+# Default config should also be in plugin root
+cp -u -v syncxml/SyncFromXML_config_default.txt "${PLUGIN_HOME}/"

--- a/ExcludedFilesLinux.txt
+++ b/ExcludedFilesLinux.txt
@@ -1,4 +1,5 @@
 - *.pyc
+- __pycache__/
 - local_launch.py
 - syncx_local.py
 - SyncFromXML_config.txt

--- a/ExcludedFilesWindows.txt
+++ b/ExcludedFilesWindows.txt
@@ -1,4 +1,5 @@
 .pyc\
+\__pycache__\
 \local_launch.py\
 \syncx_local.py\
 \SyncFromXML_config.txt\

--- a/__init__.py
+++ b/__init__.py
@@ -3,5 +3,9 @@ Anki addon that performs a one-way sync, pulling data into Anki
 from the source XML file(s) as specified in the config file.
 """
 
+# Make package-local imports work in Python 3.6 and later
+import os, sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
 from syncxml import SyncFromXML
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,4 @@
+{
+  "package": "FlashGrab",
+  "name": "FlashGrab: import LIFT XML from FieldWorks or WeSay"
+}

--- a/syncxml/SyncFromXML.py
+++ b/syncxml/SyncFromXML.py
@@ -31,8 +31,14 @@ if A.IN_ANKI:
     from anki.notes import Note
     # from anki.utils import isMac  #obsolete now, I think
     # from PyQt4.QtGui import QMessageBox  #done for us already?
-    QUESTION = QMessageBox.Question
-    CRITICAL = QMessageBox.Critical
+    try:
+        QUESTION = QMessageBox.Icon.Question
+    except AttributeError:
+        QUESTION = QMessageBox.Question
+    try:
+        CRITICAL = QMessageBox.Icon.Critical
+    except AttributeError:
+        CRITICAL = QMessageBox.Critical
 else:
     # crash-prevention dummies
     QUESTION = 0
@@ -59,7 +65,11 @@ def dialogbox(text, buttons, icon=4, log=True):
 
 def hourglass():
     if A.IN_ANKI:
-        mw.app.setOverrideCursor(QCursor(Qt.WaitCursor))  # display an hourglass cursor
+        try:
+            mw.app.setOverrideCursor(QCursor(Qt.WaitCursor))  # display an hourglass cursor
+        except AttributeError:
+            # Qt6 has moved this to CursorShape
+            mw.app.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))  # display an hourglass cursor
 def no_hourglass():
     if A.IN_ANKI:
         mw.app.restoreOverrideCursor()

--- a/syncxml/anki_util.py
+++ b/syncxml/anki_util.py
@@ -18,9 +18,9 @@ anki_user_profile = '../User 1'  #'D:\\files\\user57\\documents\\Anki\\User 1'
 
 ANKI_MEDIA_FOLDER = 'collection.media'
 
-ADDON_FOLDER = 'syncxml'
+ADDON_FOLDER = 'FlashGrab'
 APKG_PATH = os.path.join("samples", "lift-dictionary.apkg")
-NO_MODEL_INSTR = "\nSteps: Restart Anki and make sure the target deck exists. Use Tools, Manage Note Types, or go to File Import, and import Anki/addons/syncxml/{}. Or, reconfigure.)".format(APKG_PATH)
+NO_MODEL_INSTR = "\nSteps: Restart Anki and make sure the target deck exists. Use Tools, Manage Note Types, or go to File Import, and import Anki/addons/{}/{}. Or, reconfigure.)".format(ADDON_FOLDER, APKG_PATH)
 NO_MODEL_MSG = "The target model with the fields we needed was missing; have attempted to re-import the default APKG but an error occurred. \nPlease try again, or create it manually. \n{}".format(NO_MODEL_INSTR)
 TARGET_DECK = "lift-dictionary"
 

--- a/syncxml/anki_util.py
+++ b/syncxml/anki_util.py
@@ -90,7 +90,11 @@ def import_apkg_model(path, delete=False):
 #            assert deck.cardCount() > 0
 #            assert deck.noteCount() > 0
             ids = mw.col.findCards("deck:{}".format(TARGET_DECK))
-            mw.col.remCards(ids, True)
+            try:
+                mw.col.remCards(ids, True)
+            except TypeError:
+                # Newer versions of Anki renamed remCards and removed the second argument
+                mw.col.remove_cards_and_orphaned_notes(ids)
 #            assert deck.cardCount() == 0
 #            assert deck.noteCount() == 0
         except:

--- a/syncxml/flex_util.py
+++ b/syncxml/flex_util.py
@@ -22,9 +22,9 @@ def flex_dir():
     return d
 
 def flex_media(f, dir=""):
-    """Given an absolute filepath such as c:\files\Catalan.lift, and the FLEx project folder,
+    """Given an absolute filepath such as c:\\files\\Catalan.lift, and the FLEx project folder,
     check whether audio and image folders are likely to be available under, say,
-    C:\ProgramData\SIL\FieldWorks\Projects\Catalan\LinkedFiles
+    C:\\ProgramData\\SIL\\FieldWorks\\Projects\\Catalan\\LinkedFiles
     Or, given just an absolute path, assume it's an fwdata file and deduce accordingly.
     """
     media_dir = ""

--- a/syncxml/xml_util.py
+++ b/syncxml/xml_util.py
@@ -693,12 +693,11 @@ def replace_all(fname, to_replace, target=None):
 #    while os.path.exists(fname2):
 #        fname2 += ".tmp"
 
-    # using python 2.x decode()/encode() syntax below, since its open() function doesn't support this v3 parameter: encoding='utf-8'
-    with open(fname, 'r') as infile:
+    with open(fname, 'r', encoding='utf-8') as infile:
         data = infile.read()
         for pair in to_replace:
             data = re.sub(pair[0], pair[1], data)
-    with open (target, 'w') as outfile:
+    with open (target, 'w', encoding='utf-8') as outfile:
         outfile.write(data)
 
 def _workaround_px(fname):

--- a/syncxml/xml_util.py
+++ b/syncxml/xml_util.py
@@ -200,8 +200,8 @@ class XmlSettings(object):
         It only really stores the minidom, but it (and XmlSource) provide more convenient read access 
         via get methods that return string dictionaries.
         If the optional parameters are provided, they will overwrite whatever was in those
-        attributes for *every* source element. If just source_file is provided, e.g. C:\mylift\Catalan.LIFT,
-        then audio and image will be deduced, e.g. C:\mylift\audio and C:\mylift\pictures . 
+        attributes for *every* source element. If just source_file is provided, e.g. C:\\mylift\\Catalan.LIFT,
+        then audio and image will be deduced, e.g. C:\\mylift\\audio and C:\\mylift\\pictures .
         NOTE: if source_file is not provided, the other source_ parameters will be ignored.
         """
         


### PR DESCRIPTION
Modern Anki versions have moved to Python 3.13 and PyQt6, which require some changes to the plugin code to get it to work. Details are in each commit message; summary:

- Plugin install location is now `%APPDATA%\Anki2\addons21\(plugin name)`
- Python `distutils` module no longer available since Python 3.12
- Top-level plugin folder no longer automatically in import path since Python 3.6
- Anki plugins now required to include a manifest.json file
- PyQt6 moved some constant names into different namespaces

This has been tested and works with the most recent version of Anki (25.09) and will probably work on versions as far back as Anki 2.1, as when I changed the Qt code I tried to ensure it would still work under Qt5, which older versions of Anki 2.1 used to include. I have not yet tested older versions of Anki, just the most recent release.

I have also updated the helper scripts for developers (CopyFilesToAddons and so on) to take into account Anki's new plugin storage location, and used those scripts in testing Anki so I know they work.

## HOW TO TEST

Run the BuildZip.bat or BuildZip.sh script included in this PR, which should create a FlashGrab.zip file in the root of the Git repo. Open up Anki, go to the Tools -> Add-ons manager, and choose "Install from file". Install the FlashGrab.zip file and restart Anki. You should now be able to import a LIFT file (exported from FieldWorks) into Anki, which will create a deck of Anki flashcards called "lift-dictionary".